### PR TITLE
fix: fix status link on nav

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -59,7 +59,7 @@ status-website:
   introMessage: HPCSの基幹系の死活監視をします
   navbar:
     - title: Status
-      href: /
+      href: /upptime/
     - title: GitHub
       href: https://github.com/$OWNER/$REPO
     - title: HPCSLab


### PR DESCRIPTION
ヘッダーの「Status」ボタンのリンクが `https://hpcslab.github.io/upptime/` ではなく `https://hpcslab.github.io/` でリンク切れになっているのを修正します。

![Screenshot from 2025-01-10 16-50-35](https://github.com/user-attachments/assets/e0c53ca6-f87e-44ae-a925-f9b12d23893d)

